### PR TITLE
add plotGaps option to SvgLine and prevent plotting nulls by default

### DIFF
--- a/components/SvgLine.svelte
+++ b/components/SvgLine.svelte
@@ -7,10 +7,29 @@
 	export let data;
 	export let x = default_x;
 	export let y = default_y;
+    export let plotGaps = false
 
-	$: d = 'M' + data
-		.map(d => `${$x_scale(x(d))},${$y_scale(y(d))}`)
-		.join('L');
+    let d
+
+    $: if (plotGaps) {
+        d = 'M' + data
+            .map(d => `${$x_scale(x(d))},${$y_scale(y(d))}`)
+            .join('L')
+    }
+    else {
+        d = data
+            .map((d, i) => {
+                let motion = 'L'
+                if (y(d) == null) {
+                    return
+                }
+                if (i == 0 || y(data[i - 1]) == null) {
+                    motion = 'M'
+                }
+                return `${motion}${$x_scale(x(d))},${$y_scale(y(d))}`
+            })
+            .join('')
+    }
 </script>
 
 <slot {d}></slot>

--- a/components/SvgLine.svelte
+++ b/components/SvgLine.svelte
@@ -7,29 +7,29 @@
 	export let data;
 	export let x = default_x;
 	export let y = default_y;
-    export let plotGaps = false
+	export let plotGaps = false
 
-    let d
+	let d
 
-    $: if (plotGaps) {
-        d = 'M' + data
-            .map(d => `${$x_scale(x(d))},${$y_scale(y(d))}`)
-            .join('L')
-    }
-    else {
-        d = data
-            .map((d, i) => {
-                let motion = 'L'
-                if (y(d) == null) {
-                    return
-                }
-                if (i == 0 || y(data[i - 1]) == null) {
-                    motion = 'M'
-                }
-                return `${motion}${$x_scale(x(d))},${$y_scale(y(d))}`
-            })
-            .join('')
-    }
+	$: if (plotGaps) {
+		d = 'M' + data
+			.map(d => `${$x_scale(x(d))},${$y_scale(y(d))}`)
+			.join('L')
+	}
+	else {
+		d = data
+		.map((d, i) => {
+			let motion = 'L'
+			if (y(d) == null) {
+				return
+			}
+			if (i == 0 || y(data[i - 1]) == null) {
+				motion = 'M'
+			}
+			return `${motion}${$x_scale(x(d))},${$y_scale(y(d))}`
+		})
+		.join('')
+	}
 </script>
 
 <slot {d}></slot>


### PR DESCRIPTION
In our use case nulls are very significant. Right now they are plotted as 0s and to me it makes more sense that the default is to show gaps in the SvgLine. I've added `plotGaps` option that when `true` will plot them as 0.