### PR TITLE
fix date function so all months display in tooltip

### DIFF
--- a/site/examples/data/0/App.svelte
+++ b/site/examples/data/0/App.svelte
@@ -36,7 +36,7 @@
 
 	const format = date => {
 		const year = ~~date;
-		const month = Math.floor((date % 1) * 1.2);
+		const month = Math.floor((date % 1) * 12);
 
 		return `${months[month]} ${year}`;
 	};


### PR DESCRIPTION
The atmospheric Co2 figure on the pancake home page incorrectly displays the months for the data points. It's literally just a decimal point but it works now.