### PR TITLE
Add max_levels parameter to Quadtree algorithm

### DIFF
--- a/components/Quadtree.svelte
+++ b/components/Quadtree.svelte
@@ -11,11 +11,12 @@
 
 	// exposing the prop lets consumers use let: or bind:
 	export let closest = undefined;
+	export let maxLevels = undefined;
 
 	const { pointer, x_scale, y_scale, x_scale_inverse, y_scale_inverse, width, height } = getChartContext();
 	const dispatch = createEventDispatcher();
 
-	$: quadtree = new Quadtree(data);
+	$: quadtree = new Quadtree(data, maxLevels);
 	$: quadtree.update(x, y, $x_scale, $y_scale);
 
 	// track reference changes, to trigger updates sparingly


### PR DESCRIPTION
This PR fixes #24. 

The current Quadtree implementation does not have any limits on how many sub-trees it can have. This causes an infinite recursion problem, whenever you're plotting two or more lines. From what I understood, **two points close enough to another causes the algorithm to recursively split them**. Because there's no limit, **it keeps splitting the nodes until it crashes.**

The current fix adds a `max_levels` parameter to the Quadtree implementation, controlling how deep the tree could grow. Initially, I thought this was a hotfix, not being the correct way to solve this problem. However, looking at other libraries such as [Quadtree JS](https://github.com/timohausmann/quadtree-js/blob/master/quadtree.js#L166), it looks they also fixed this issue in a very similar way.

I created a new prop `maxLevels` for the `Quadtree` component, allowing the users to override the default value for this property. For my use case, `10` proved to be the minimum value that gave the results I needed, therefore, it currently defaults to `10`.

## Example Usage

- Changing the max level value for the Quadtree algorithm
```svelte
<Quadtree data={points} maxLevels={5} bind:closest />
```

- Using the default value of 10
```svelte
<Quadtree data={points} bind:closest />
```
